### PR TITLE
Add illumos support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,8 @@ fn it_works() {
 fn check_description() {
     let expect = if cfg!(windows) {
         "Incorrect function."
+    } else if cfg!(target_os = "illumos") {
+        "Not owner"
     } else if cfg!(target_os = "wasi") {
         "Argument list too long"
     } else {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -60,7 +60,8 @@ extern {
                    target_os = "bitrig",
                    target_os = "android"),
                link_name = "__errno")]
-    #[cfg_attr(target_os = "solaris",
+    #[cfg_attr(any(target_os = "solaris",
+                   target_os = "illumos"),
                link_name = "___errno")]
     #[cfg_attr(target_os = "linux",
                link_name = "__errno_location")]


### PR DESCRIPTION
Hi!

I was trying to install `cargo-info` on an illumos machine, and it depends on this library.  With this change, the `errno` crate builds and the tests pass on a recent illumos system:

```
$ cat /etc/release
             OpenIndiana Hipster 2020.04 (powered by illumos)
        OpenIndiana Project, part of The Illumos Foundation (C) 2010-2020
                        Use is subject to license terms.
                           Assembled 03 May 2020
$ uname -a
SunOS newcastle 5.11 rti-master-0-g6682e4c38c i86pc i386 i86pc


$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running target/debug/deps/errno-f41b053e0159cdd2

running 3 tests
test check_error_into_errno ... ok
test it_works ... ok
test check_description ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests errno

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```