### PR TITLE
add support of RustyHermit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,8 @@ errno-dragonfly = "0.1.1"
 [target.'cfg(target_os="wasi")'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os="hermit")'.dependencies]
+libc = "0.2"
+
 [badges]
 travis-ci = { repository = "lambda-fairy/rust-errno" }

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -1,0 +1,32 @@
+//! Implementation of `errno` functionality for RustyHermit.
+//!
+//! Currently, the error handling in RustyHermit isn't clearly
+//! defined. At the current stage of RustyHermit, only a placeholder
+//! is provided to be compatible to the classical errno interface.
+
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use Errno;
+
+pub fn with_description<F, T>(_err: Errno, callback: F) -> T where
+    F: FnOnce(Result<&str, Errno>) -> T
+{
+    callback(Ok("unknown error"))
+}
+
+pub const STRERROR_NAME: &'static str = "strerror_r";
+
+pub fn errno() -> Errno {
+    Errno(0)
+}
+
+pub fn set_errno(_: Errno) {
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,12 @@
 #[cfg(windows)] extern crate winapi;
 #[cfg(target_os = "dragonfly")] extern crate errno_dragonfly;
 #[cfg(target_os = "wasi")] extern crate libc;
+#[cfg(target_os = "hermit")] extern crate libc;
 
 #[cfg_attr(unix, path = "unix.rs")]
 #[cfg_attr(windows, path = "windows.rs")]
 #[cfg_attr(target_os = "wasi", path = "wasi.rs")]
+#[cfg_attr(target_os = "hermit", path = "hermit.rs")]
 mod sys;
 
 use std::fmt;


### PR DESCRIPTION
Currently, the error handling in RustyHermit [(hermitcore/rusty-hermit)](https://github.com/hermitcore/rusty-hermit) isn't clearly
defined. At the current stage of RustyHermit, only a placeholder
is provided to be compatible to the classical errno interface.