### PR TITLE
Add minimum lines for ::std::error::Error implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,13 @@ impl Into<i32> for Errno {
     }
 }
 
-impl Error for Errno {}
+impl Error for Errno {
+    // TODO: Remove when MSRV >= 1.27
+    #[allow(deprecated)]
+    fn description(&self) -> &str {
+        "system error"
+    }
+}
 
 impl From<Errno> for io::Error {
     fn from(errno: Errno) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod sys;
 
 use std::fmt;
 use std::io;
+use std::error::Error;
 
 /// Wraps a platform-specific error code.
 ///
@@ -72,6 +73,8 @@ impl Into<i32> for Errno {
         self.0
     }
 }
+
+impl Error for Errno {}
 
 impl From<Errno> for io::Error {
     fn from(errno: Errno) -> Self {


### PR DESCRIPTION
To compile below with current (1.47) rustc:

    fn f<E: ::std::error::Error>(e: E) {}
    fn main() {
        f(errnor::Errno(0));
    }