### PR TITLE
no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,26 @@ repository = "https://github.com/lambda-fairy/rust-errno"
 description = "Cross-platform interface to the `errno` variable."
 categories = ["os"]
 
+[features]
+default = ["std"]
+std = ["libc/default"]
+
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+cstr_core = { version = "0.2.4", default-features = false }
+libc = { version = "0.2", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["errhandlingapi", "minwindef", "ntdef", "winbase"] }
 
 [target.'cfg(target_os="dragonfly")'.dependencies]
-errno-dragonfly = "0.1.1"
+errno-dragonfly = "0.1.2"
 
 [target.'cfg(target_os="wasi")'.dependencies]
-libc = "0.2"
+cstr_core = { version = "0.2.4", default-features = false }
+libc = { version = "0.2", default-features = false }
 
 [target.'cfg(target_os="hermit")'.dependencies]
-libc = "0.2"
+libc = { version = "0.2", default-features = false }
 
 [badges]
 travis-ci = { repository = "lambda-fairy/rust-errno" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,15 @@
 
 #![cfg_attr(target_os = "wasi", feature(thread_local))]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+#[cfg(feature = "std")] extern crate core;
+#[cfg(unix)] extern crate cstr_core;
 #[cfg(unix)] extern crate libc;
 #[cfg(windows)] extern crate winapi;
 #[cfg(target_os = "dragonfly")] extern crate errno_dragonfly;
+#[cfg(target_os = "wasi")] extern crate cstr_core;
 #[cfg(target_os = "wasi")] extern crate libc;
 #[cfg(target_os = "hermit")] extern crate libc;
 
@@ -31,9 +37,11 @@
 #[cfg_attr(target_os = "hermit", path = "hermit.rs")]
 mod sys;
 
-use std::fmt;
-use std::io;
+use core::fmt;
+#[cfg(feature = "std")]
 use std::error::Error;
+#[cfg(feature = "std")]
+use std::io;
 
 /// Wraps a platform-specific error code.
 ///
@@ -74,6 +82,7 @@ impl Into<i32> for Errno {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for Errno {
     // TODO: Remove when MSRV >= 1.27
     #[allow(deprecated)]
@@ -82,6 +91,7 @@ impl Error for Errno {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<Errno> for io::Error {
     fn from(errno: Errno) -> Self {
         io::Error::from_raw_os_error(errno.0)

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -12,7 +12,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ffi::CStr;
+use alloc::string::String;
+use cstr_core::CStr;
 use libc::{self, c_char, c_int};
 #[cfg(target_os = "dragonfly")]
 use errno_dragonfly::errno_location;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -12,7 +12,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ffi::CStr;
+use alloc::string::String;
+use cstr_core::CStr;
 use libc::{self, c_char, c_int};
 
 use Errno;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -12,7 +12,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ptr;
+use alloc::string::String;
+use core::ptr;
 use winapi::shared::minwindef::DWORD;
 use winapi::shared::ntdef::WCHAR;
 use winapi::um::winbase::{FORMAT_MESSAGE_FROM_SYSTEM, FORMAT_MESSAGE_IGNORE_INSERTS};


### PR DESCRIPTION
Some additional remarks:

1. The `std = ["libc/default"]` line in  `Cargo.toml` has added for compatibility only, and this is rather an overinsurance. In new major version (0.3) it is better to change this line to `std = []`.
2. `cargo test --no-default-features` does not work. It is easy to make it works though if needed, so let me know if you need this command to work and not throw errors.
3. The crate still has dependence (explicit now) on `alloc` crate. I do not need avoiding dynamic allocations and `alloc` dependence for my personal purposes now, but some `no_std`-people may have such need. For such people this pull request is first, but not last step in `no_std` direction.