### PR TITLE
add haiku support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Unreleased]
 
+- Add haiku support
+  [#42](https://github.com/lambda-fairy/rust-errno/pull/42)
+
 - Remove unused `winapi` features for `#![no_std]`
   [#40](https://github.com/lambda-fairy/rust-errno/pull/40)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,16 +128,19 @@ fn check_description() {
         "Not owner"
     } else if cfg!(target_os = "wasi") {
         "Argument list too long"
+    } else if cfg!(target_os = "haiku") {
+        "Operation not allowed"
     } else {
         "Operation not permitted"
     };
 
-    set_errno(Errno(1));
+    let errno_code = if cfg!(target_os = "haiku") { -2147483633 } else { 1 };
+    set_errno(Errno(errno_code));
 
     assert_eq!(errno().to_string(), expect);
     assert_eq!(
         format!("{:?}", errno()),
-        format!("Errno {{ code: 1, description: Some({:?}) }}", expect));
+        format!("Errno {{ code: {}, description: Some({:?}) }}", errno_code, expect));
 }
 
 #[cfg(feature = "std")]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -68,6 +68,8 @@ extern {
     #[cfg_attr(any(target_os = "solaris",
                    target_os = "illumos"),
                link_name = "___errno")]
+    #[cfg_attr(target_os = "haiku",
+               link_name = "_errnop")]
     #[cfg_attr(target_os = "linux",
                link_name = "__errno_location")]
     fn errno_location() -> *mut c_int;


### PR DESCRIPTION
this pr adds haiku support

below is a sample excerpt showing a build and test run on a haiku system 

```shell
> uname -a
Haiku shredder 1 hrev55795 Jan 23 2022 07:04:09 x86_64 x86_64 Haiku

> cargo test
   Compiling libc v0.2.79
   Compiling errno v0.2.8 (/boot/home/src/git/rust-libs/rust-errno)
    Finished test [unoptimized + debuginfo] target(s) in 2.33s
     Running unittests (target/debug/deps/errno-dcb60f68e1c4165d)

running 4 tests
test check_error_into_errno ... ok
test it_works ... ok
test it_works_with_to_string ... ok
test check_description ... FAILED

failures:

---- check_description stdout ----
thread 'check_description' panicked at 'assertion failed: `(left == right)`
  left: `"OS error 1 (strerror_r returned error 1)"`,
 right: `"Operation not permitted"`', src/lib.rs:137:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    check_description

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass '--lib'
```

i have left the test that is not passing on haiku as is. getting the test to pass as is  on haiku is most likely not possible as *strerror_r*  behaves differently on haiku. rather than modify the test logic too much, it might be better to suppress this test for haiku. the following is an example to help illustrate the behavior difference.

```
> cat main.c
#include <stdio.h>
#include <string.h>
#include <errno.h>

int main(int argc, char **argv){
	char buf[1024]; 
	int i;
	buf[0] = 0;
	
	i = strerror_r(1, buf, 2048);
	printf("strerror_r(1) returns: %d buf contents:: %s\n", i, buf);

	i = strerror_r(EPERM, buf, 2048);
	printf("strerror_r(%d) returns: %d buf contents:: %s\n", EPERM, i, buf);
}

> gcc -Wall main.c 
> ./a.out 
strerror_r(1) returns: -2147483643 buf contents:: 
strerror_r(-2147483633) returns: 0 buf contents:: Operation not allowed
```

