### PR TITLE
Bump MSRV to 1.36

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, nightly, 1.13.0]
-        exclude:
-          # https://github.com/rust-lang/rust/issues/34674
-          - os: macos-latest
-            rust: 1.13.0
+        rust: [stable, nightly, 1.30.0]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, nightly, 1.30.0]
+        rust: [stable, nightly, 1.36.0]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 - Add formatting with `#![no_std]`
   [#44](https://github.com/lambda-fairy/rust-errno/pull/44)
+ 
+- Update minimum Rust version to 1.36
+  [#48](https://github.com/lambda-fairy/rust-errno/pull/48)
 
 # [0.2.8] - 2021-10-27
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # errno [![CI](https://github.com/lambda-fairy/rust-errno/actions/workflows/main.yml/badge.svg)](https://github.com/lambda-fairy/rust-errno/actions/workflows/main.yml) [![Cargo](https://img.shields.io/crates/v/errno.svg)](https://crates.io/crates/errno)
 
-Cross-platform interface to the [`errno`][errno] variable. Works on Rust 1.13 or newer.
+Cross-platform interface to the [`errno`][errno] variable. Works on Rust 1.36 or newer.
 
 Documentation is available at <https://docs.rs/errno>.
 


### PR DESCRIPTION
Rust 1.36 is the earliest version that supports [`Iterator::copied`](https://doc.rust-lang.org/stable/std/iter/struct.Copied.html).

Per https://github.com/lambda-fairy/rust-errno/pull/44#discussion_r870957790, Rust 1.36 should be okay with our biggest dependents `caps` and `rustix`.

Fixes #47