### PR TITLE
Switch from winapi to windows-sys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, nightly, 1.36.0]
+        rust: [stable, nightly, 1.48]
         exclude:
           # TODO(#52): Investigate why this is broken
           - os: macos-latest
-            rust: 1.36.0
+            rust: 1.48
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 
 - Add formatting with `#![no_std]`
   [#44](https://github.com/lambda-fairy/rust-errno/pull/44)
- 
-- Update minimum Rust version to 1.36
-  [#48](https://github.com/lambda-fairy/rust-errno/pull/48)
+
+- Switch from `winapi` to `windows-sys` [#55](https://github.com/lambda-fairy/rust-errno/pull/55)
+
+- Update minimum Rust version to 1.48
+  [#48](https://github.com/lambda-fairy/rust-errno/pull/48) [#55](https://github.com/lambda-fairy/rust-errno/pull/55)
 
 # [0.2.8] - 2021-10-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,12 @@ categories = ["no-std", "os"]
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["errhandlingapi", "minwindef", "ntdef", "winbase"] }
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.42"
+features = [
+  "Win32_Foundation",
+  "Win32_System_Diagnostics_Debug",
+]
 
 [target.'cfg(target_os="dragonfly")'.dependencies]
 errno-dragonfly = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # errno [![CI](https://github.com/lambda-fairy/rust-errno/actions/workflows/main.yml/badge.svg)](https://github.com/lambda-fairy/rust-errno/actions/workflows/main.yml) [![Cargo](https://img.shields.io/crates/v/errno.svg)](https://crates.io/crates/errno)
 
-Cross-platform interface to the [`errno`][errno] variable. Works on Rust 1.36 or newer.
+Cross-platform interface to the [`errno`][errno] variable. Works on Rust 1.48 or newer.
 
 Documentation is available at <https://docs.rs/errno>.
 

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -16,8 +16,9 @@
 
 use Errno;
 
-pub fn with_description<F, T>(_err: Errno, callback: F) -> T where
-    F: FnOnce(Result<&str, Errno>) -> T
+pub fn with_description<F, T>(_err: Errno, callback: F) -> T
+where
+    F: FnOnce(Result<&str, Errno>) -> T,
 {
     callback(Ok("unknown error"))
 }
@@ -28,5 +29,4 @@ pub fn errno() -> Errno {
     Errno(0)
 }
 
-pub fn set_errno(_: Errno) {
-}
+pub fn set_errno(_: Errno) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,16 @@
 #[cfg(feature = "std")]
 extern crate core;
 
-#[cfg(unix)] extern crate libc;
-#[cfg(windows)] extern crate winapi;
-#[cfg(target_os = "dragonfly")] extern crate errno_dragonfly;
-#[cfg(target_os = "wasi")] extern crate libc;
-#[cfg(target_os = "hermit")] extern crate libc;
+#[cfg(target_os = "dragonfly")]
+extern crate errno_dragonfly;
+#[cfg(unix)]
+extern crate libc;
+#[cfg(target_os = "wasi")]
+extern crate libc;
+#[cfg(target_os = "hermit")]
+extern crate libc;
+#[cfg(windows)]
+extern crate winapi;
 
 #[cfg_attr(unix, path = "unix.rs")]
 #[cfg_attr(windows, path = "windows.rs")]
@@ -37,9 +42,9 @@ mod sys;
 
 use core::fmt;
 #[cfg(feature = "std")]
-use std::io;
-#[cfg(feature = "std")]
 use std::error::Error;
+#[cfg(feature = "std")]
+use std::io;
 
 /// Wraps a platform-specific error code.
 ///
@@ -68,8 +73,12 @@ impl fmt::Display for Errno {
         sys::with_description(*self, |desc| match desc {
             Ok(desc) => fmt.write_str(&desc),
             Err(fm_err) => write!(
-                fmt, "OS error {} ({} returned error {})",
-                self.0, sys::STRERROR_NAME, fm_err.0),
+                fmt,
+                "OS error {} ({} returned error {})",
+                self.0,
+                sys::STRERROR_NAME,
+                fm_err.0
+            ),
         })
     }
 }
@@ -134,13 +143,21 @@ fn check_description() {
         "Operation not permitted"
     };
 
-    let errno_code = if cfg!(target_os = "haiku") { -2147483633 } else { 1 };
+    let errno_code = if cfg!(target_os = "haiku") {
+        -2147483633
+    } else {
+        1
+    };
     set_errno(Errno(errno_code));
 
     assert_eq!(errno().to_string(), expect);
     assert_eq!(
         format!("{:?}", errno()),
-        format!("Errno {{ code: {}, description: Some({:?}) }}", errno_code, expect));
+        format!(
+            "Errno {{ code: {}, description: Some({:?}) }}",
+            errno_code, expect
+        )
+    );
 }
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ extern crate libc;
 #[cfg(target_os = "hermit")]
 extern crate libc;
 #[cfg(windows)]
-extern crate winapi;
+extern crate windows_sys;
 
 #[cfg_attr(unix, path = "unix.rs")]
 #[cfg_attr(windows, path = "windows.rs")]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,9 +15,10 @@
 use core::char::{self, REPLACEMENT_CHARACTER};
 use core::ptr;
 use core::str;
-use winapi::shared::minwindef::DWORD;
-use winapi::shared::ntdef::WCHAR;
-use winapi::um::winbase::{FORMAT_MESSAGE_FROM_SYSTEM, FORMAT_MESSAGE_IGNORE_INSERTS};
+use windows_sys::Win32::Foundation::{GetLastError, SetLastError, WIN32_ERROR};
+use windows_sys::Win32::System::Diagnostics::Debug::{
+    FormatMessageW, FORMAT_MESSAGE_FROM_SYSTEM, FORMAT_MESSAGE_IGNORE_INSERTS,
+};
 
 use Errno;
 
@@ -42,18 +43,18 @@ where
 {
     // This value is calculated from the macro
     // MAKELANGID(LANG_SYSTEM_DEFAULT, SUBLANG_SYS_DEFAULT)
-    let lang_id = 0x0800 as DWORD;
+    let lang_id = 0x0800_u32;
 
-    let mut buf = [0 as WCHAR; 2048];
+    let mut buf = [0u16; 2048];
 
     unsafe {
-        let res = ::winapi::um::winbase::FormatMessageW(
+        let res = FormatMessageW(
             FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
             ptr::null_mut(),
-            err.0 as DWORD,
+            err.0 as u32,
             lang_id,
             buf.as_mut_ptr(),
-            buf.len() as DWORD,
+            buf.len() as u32,
             ptr::null_mut(),
         );
         if res == 0 {
@@ -73,9 +74,9 @@ where
 pub const STRERROR_NAME: &'static str = "FormatMessageW";
 
 pub fn errno() -> Errno {
-    unsafe { Errno(::winapi::um::errhandlingapi::GetLastError() as i32) }
+    unsafe { Errno(GetLastError() as i32) }
 }
 
 pub fn set_errno(Errno(errno): Errno) {
-    unsafe { ::winapi::um::errhandlingapi::SetLastError(errno as DWORD) }
+    unsafe { SetLastError(errno as WIN32_ERROR) }
 }


### PR DESCRIPTION
The first commit is a pure `cargo fmt` run to get a clean slate. The second commit is more interesting and switches from `winapi` to the `windows-sys`, which is maintained by Microsoft.

The wider ecosystem appears to be switching. Let's follow suit so depentents don't have to compile both. At least in my dependency trees `errno` is one of the last holdouts.

This raises the MSRV to 1.48. For the last MSRV bump `caps` and `rustix` were considered. `rustix` already depends on `windows-sys` is interested in having this change while `caps` has since dropped their dependency on `errno` (both per https://github.com/lucab/caps-rs/pull/79).

I have ideas for a few more cleanups/minor fixes but they would collide with these changes, so it would be best to merge this first.