### PR TITLE
Switch to Rust 2018 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Update minimum Rust version to 1.48
   [#48](https://github.com/lambda-fairy/rust-errno/pull/48) [#55](https://github.com/lambda-fairy/rust-errno/pull/55)
 
+- Upgrade to Rust 2018 edition [#59](https://github.com/lambda-fairy/rust-errno/pull/59)
+
 # [0.2.8] - 2021-10-27
 
 - Optionally support no_std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.2.8"
 authors = ["Chris Wong <lambda.fairy@gmail.com>"]
 
 license = "MIT OR Apache-2.0"
+edition = "2018"
 documentation = "https://docs.rs/errno"
 repository = "https://github.com/lambda-fairy/rust-errno"
 description = "Cross-platform interface to the `errno` variable."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,20 +20,6 @@
 #![cfg_attr(target_os = "wasi", feature(thread_local))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
-extern crate core;
-
-#[cfg(target_os = "dragonfly")]
-extern crate errno_dragonfly;
-#[cfg(unix)]
-extern crate libc;
-#[cfg(target_os = "wasi")]
-extern crate libc;
-#[cfg(target_os = "hermit")]
-extern crate libc;
-#[cfg(windows)]
-extern crate windows_sys;
-
 #[cfg_attr(unix, path = "unix.rs")]
 #[cfg_attr(windows, path = "windows.rs")]
 #[cfg_attr(target_os = "wasi", path = "wasi.rs")]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -17,7 +17,7 @@ use core::str;
 use errno_dragonfly::errno_location;
 use libc::{self, c_char, c_int, strlen};
 
-use Errno;
+use crate::Errno;
 
 fn from_utf8_lossy(input: &[u8]) -> &str {
     match str::from_utf8(input) {

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -15,7 +15,7 @@
 use core::str;
 use libc::{self, c_char, c_int, strlen};
 
-use Errno;
+use crate::Errno;
 
 fn from_utf8_lossy(input: &[u8]) -> &str {
     match str::from_utf8(input) {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -20,7 +20,7 @@ use windows_sys::Win32::System::Diagnostics::Debug::{
     FormatMessageW, FORMAT_MESSAGE_FROM_SYSTEM, FORMAT_MESSAGE_IGNORE_INSERTS,
 };
 
-use Errno;
+use crate::Errno;
 
 fn from_utf16_lossy<'a>(input: &[u16], output: &'a mut [u8]) -> &'a str {
     let mut output_len = 0;


### PR DESCRIPTION
It was introduced with Rust 1.31 and the current MSRV is 1.48. No need to hold this back any longer.