### PR TITLE
Add `rust-version` field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/errno"
 repository = "https://github.com/lambda-fairy/rust-errno"
 description = "Cross-platform interface to the `errno` variable."
 categories = ["no-std", "os"]
+rust-version = "1.48"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
This field tells cargo about errno's MSRV. It was added with Rust 1.56. Older versions will print a warning about an unknown field if errno is the top-level build job. If errno is merely compiled as a dependency, no warning is printed.

Even though errno's MSRV is currenlty 1.48, it would be good to make this metadata available in a standarized machine-readable format.