### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot will automatically file PRs for updatable dependencies. The cargo section watches `Cargo.toml` while the github-actions section watches the workflow files in `.github/workflows` for possible updates to any of the action in use.

Best to merge this after https://github.com/lambda-fairy/rust-errno/pull/60. Dependabot will open a PR updating `actions/checkout` to `v3` once this is merged. It will auto-rebase if you merge https://github.com/lambda-fairy/rust-errno/pull/60 in between, but it might take a few minutes.