### PR TITLE
wasm32-wasi: Use `__errno_location` instead of `feature(thread_local)`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 //! println!("Error {}: {}", code, e);
 //! ```
 
-#![cfg_attr(target_os = "wasi", feature(thread_local))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg_attr(unix, path = "unix.rs")]

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -45,21 +45,16 @@ where
 pub const STRERROR_NAME: &str = "strerror_r";
 
 pub fn errno() -> Errno {
-    // libc_errno is thread-local, so simply read its value.
-    unsafe { Errno(libc_errno) }
+    unsafe { Errno(*__errno_location()) }
 }
 
 pub fn set_errno(Errno(new_errno): Errno) {
-    // libc_errno is thread-local, so simply assign to it.
     unsafe {
-        libc_errno = new_errno;
+        *__errno_location() = new_errno;
     }
 }
 
 extern "C" {
-    #[thread_local]
-    #[link_name = "errno"]
-    static mut libc_errno: c_int;
-
+    fn __errno_location() -> *mut c_int;
     fn strerror_r(errnum: c_int, buf: *mut c_char, buflen: size_t) -> c_int;
 }


### PR DESCRIPTION
Recent versions of wasi-libc provide an `__errno_location` function which returns the address of errno, similar to other platforms. Change the errno crate to use that, instead of using the unstable `feature(thread_local)`.

At the moment, only Rust nightly has a new enough wasi-libc to support this, however it's not a regression because the `feature(thread_local)` already dependend on nightly. In the future, the newer wasi-libc will be in stable Rust too, making this work on stable.