### PR TITLE
Support for the ESP-IDF framework

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -67,7 +67,8 @@ extern "C" {
             target_os = "openbsd",
             target_os = "netbsd",
             target_os = "bitrig",
-            target_os = "android"
+            target_os = "android",
+            target_os = "espidf"
         ),
         link_name = "__errno"
     )]


### PR DESCRIPTION
Subject says it all - we we would like to extend support for the ESP IDF framework to this crate as well (it is already supported in Rust STD, `libc`, `rustix`, `socket2` and others.)
