### PR TITLE
Bump errno-dragonfly to remove `gcc` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = [
 ]
 
 [target.'cfg(target_os="dragonfly")'.dependencies]
-errno-dragonfly = "0.1.1"
+errno-dragonfly = "0.1.2"
 
 [target.'cfg(target_os="wasi")'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
This PR bumps the version of `errno-dragonfly`. Even though this dependency is only for `target-os="dragonfly"`, it (and its dependencies) would still get downloaded and type checked on other platforms. This can be problematic since version 0.1.1 specifies `gcc 0.3.0` as a dependency which would cause all dependants to fail when using `-Z minimal-versions` to build (for more info, see [here](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277)). Since 0.1.2, they've switched to `cc v1.0` which does build correctly on current versions of rust.

Essentially, this PR unblocks a lot of indirectly dependent crates from using `-Z minimal-versions` once a new release is made, which can have a wide impact on the ecosystem since `rust-errno` is indirectly used by popular crates such as `clap`, `env_logger`, `tempfile`, `tokio`, `criterion`, etc.