### PR TITLE
Use __errno_location on DragonFly BSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ features = [
   "Win32_System_Diagnostics_Debug",
 ]
 
-[target.'cfg(target_os="dragonfly")'.dependencies]
-errno-dragonfly = "0.1.2"
-
 [target.'cfg(target_os="wasi")'.dependencies]
 libc = { version = "0.2", default-features = false }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -13,8 +13,6 @@
 // except according to those terms.
 
 use core::str;
-#[cfg(target_os = "dragonfly")]
-use errno_dragonfly::errno_location;
 use libc::{self, c_char, c_int, size_t, strlen};
 
 use crate::Errno;
@@ -57,7 +55,6 @@ pub fn set_errno(Errno(errno): Errno) {
 }
 
 extern "C" {
-    #[cfg(not(target_os = "dragonfly"))]
     #[cfg_attr(
         any(target_os = "macos", target_os = "ios", target_os = "freebsd"),
         link_name = "__error"
@@ -78,7 +75,12 @@ extern "C" {
     )]
     #[cfg_attr(target_os = "haiku", link_name = "_errnop")]
     #[cfg_attr(
-        any(target_os = "linux", target_os = "hurd", target_os = "redox"),
+        any(
+            target_os = "linux",
+            target_os = "hurd",
+            target_os = "redox",
+            target_os = "dragonfly"
+        ),
         link_name = "__errno_location"
     )]
     #[cfg_attr(target_os = "aix", link_name = "_Errno")]


### PR DESCRIPTION
DragonFly BSD 5.8+ has __errno_location.
https://github.com/DragonFlyBSD/DragonFlyBSD/commit/60d311380ff2bf02a87700a0f3e6eb53e6034920