### PR TITLE
Add support for tvOS and watchOS

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -56,7 +56,13 @@ pub fn set_errno(Errno(errno): Errno) {
 
 extern "C" {
     #[cfg_attr(
-        any(target_os = "macos", target_os = "ios", target_os = "freebsd"),
+        any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "watchos",
+            target_os = "freebsd"
+        ),
         link_name = "__error"
     )]
     #[cfg_attr(


### PR DESCRIPTION
They have the same errno API as iOS.

https://github.com/rust-lang/rust/blob/d1611e39c43e26333ba989cedbd63117be798741/library/std/src/sys/unix/os.rs#L66-L72