### PR TITLE
Use libc::strerror_r instead of our own definition

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -13,7 +13,7 @@
 // except according to those terms.
 
 use core::str;
-use libc::{self, c_char, c_int, size_t, strlen};
+use libc::{self, c_int, size_t, strerror_r, strlen};
 
 use crate::Errno;
 
@@ -86,10 +86,4 @@ extern "C" {
     #[cfg_attr(target_os = "aix", link_name = "_Errno")]
     #[cfg_attr(target_os = "nto", link_name = "__get_errno_ptr")]
     fn errno_location() -> *mut c_int;
-
-    #[cfg_attr(
-        any(target_os = "linux", target_os = "hurd"),
-        link_name = "__xpg_strerror_r"
-    )]
-    fn strerror_r(errnum: c_int, buf: *mut c_char, buflen: size_t) -> c_int;
 }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -13,7 +13,7 @@
 // except according to those terms.
 
 use core::str;
-use libc::{self, c_char, c_int, size_t, strlen};
+use libc::{self, c_int, size_t, strerror_r, strlen};
 
 use crate::Errno;
 
@@ -56,5 +56,4 @@ pub fn set_errno(Errno(new_errno): Errno) {
 
 extern "C" {
     fn __errno_location() -> *mut c_int;
-    fn strerror_r(errnum: c_int, buf: *mut c_char, buflen: size_t) -> c_int;
 }


### PR DESCRIPTION
We already depend on libc to use strlen, and libc provides strerror_r for all unix/wasi platforms we support.

(As for errno_location, it seems that libc does not provide a corresponding one for some platforms yet.)