### PR TITLE
Added support for vita target

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -71,7 +71,8 @@ extern "C" {
             target_os = "netbsd",
             target_os = "bitrig",
             target_os = "android",
-            target_os = "espidf"
+            target_os = "espidf",
+            target_os = "vita"
         ),
         link_name = "__errno"
     )]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -72,7 +72,7 @@ extern "C" {
             target_os = "bitrig",
             target_os = "android",
             target_os = "espidf",
-            target_os = "vita"
+            target_env = "newlib"
         ),
         link_name = "__errno"
     )]


### PR DESCRIPTION
Added support for tier 3 [armv7-sony-vita-newlibeabihf](https://doc.rust-lang.org/rustc/platform-support/armv7-sony-vita-newlibeabihf.html) target.

Rust std [actually defines](https://github.com/rust-lang/rust/blob/c5afe0a61e39bdd912803eae8d1887a513bdd172/library/std/src/sys/unix/os.rs#L60C13-L60C34) that by `target_env = "newlib"`, but I am not entirely sure about other newlib targets.

If the goal is to align with std, I can change it to that.