### PR TITLE
Fix strerror_r error test

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -30,8 +30,13 @@ where
 {
     let mut buf = [0u8; 1024];
     let c_str = unsafe {
-        if strerror_r(err.0, buf.as_mut_ptr() as *mut _, buf.len() as size_t) < 0 {
-            let fm_err = errno();
+        let rc = strerror_r(err.0, buf.as_mut_ptr() as *mut _, buf.len() as size_t);
+        if rc != 0 {
+            // Handle negative return codes for compatibility with glibc < 2.13
+            let fm_err = match rc < 0 {
+                true => errno(),
+                false => Errno(rc),
+            };
             if fm_err != Errno(libc::ERANGE) {
                 return callback(Err(fm_err));
             }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -30,8 +30,9 @@ where
 {
     let mut buf = [0u8; 1024];
     let c_str = unsafe {
-        if strerror_r(err.0, buf.as_mut_ptr() as *mut _, buf.len() as size_t) < 0 {
-            let fm_err = errno();
+        let rc = strerror_r(err.0, buf.as_mut_ptr() as *mut _, buf.len() as size_t);
+        if rc != 0 {
+            let fm_err = Errno(rc);
             if fm_err != Errno(libc::ERANGE) {
                 return callback(Err(fm_err));
             }


### PR DESCRIPTION
Fixes https://github.com/lambda-fairy/rust-errno/issues/45.

`man 3 strerror_r` says:

The XSI-compliant strerror_r() function returns 0 on success. On error, a (positive) error number is returned (since glibc 2.13), or -1 is returned and errno is set to indicate the error (glibc versions before 2.13).