### PR TITLE
Add visionOS support

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -66,6 +66,7 @@ extern "C" {
             target_os = "ios",
             target_os = "tvos",
             target_os = "watchos",
+            target_os = "visionos",
             target_os = "freebsd"
         ),
         link_name = "__error"


### PR DESCRIPTION
This is to support the apple vision pro. This target was added in https://github.com/rust-lang/rust/pull/121419 and the `target_os` is `visionos`.