### PR TITLE
Remove Bitrig support

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -75,7 +75,6 @@ extern "C" {
         any(
             target_os = "openbsd",
             target_os = "netbsd",
-            target_os = "bitrig",
             target_os = "android",
             target_os = "espidf",
             target_env = "newlib"


### PR DESCRIPTION
Bitrig support was removed upstream in rust-lang/rust#60775. From the [merge commit][1] it landed in 1.36.0 which is long before our MSRV of Rust 1.56.

This also fixes the `unexpected_cfgs` warning.

[1]: https://github.com/rust-lang/rust/commit/c84a7abf8b2c5753179472464dc2baeb86c6fed6