### PR TITLE
Add cygwin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Add VxWorks support
   [#105](https://github.com/lambda-fairy/rust-errno/pull/105)
 
+- Add cygwin support
+  [#106](https://github.com/lambda-fairy/rust-errno/pull/106)
+
 # [0.3.10] - 2024-11-29
 
 - Update to windows-sys 0.59

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ libc = { version = "0.2", default-features = false }
 default = ["std"]
 std = ["libc/std"]
 
+# TODO: Remove this exemption when Cygwin support lands in Rust stable
+# https://github.com/rust-lang/rust/pull/134999
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(target_os, values("cygwin"))']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ libc = { version = "0.2", default-features = false }
 [features]
 default = ["std"]
 std = ["libc/std"]
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(target_os, values("cygwin"))']

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Cygwin target, added in 1.86
+    println!("cargo:rustc-check-cfg=cfg(target_os, values(\"cygwin\"))");
+}

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    // Cygwin target, added in 1.86
-    println!("cargo:rustc-check-cfg=cfg(target_os, values(\"cygwin\"))");
-}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -78,6 +78,7 @@ extern "C" {
             target_os = "android",
             target_os = "espidf",
             target_os = "vxworks",
+            target_os = "cygwin",
             target_env = "newlib"
         ),
         link_name = "__errno"


### PR DESCRIPTION
This PR adds cygwin support, which uses `__errno`.

Blocking:
- [x] https://github.com/rust-lang/libc/pull/4308